### PR TITLE
fix: correct falied→failed typo in print statement

### DIFF
--- a/src/models/base_model.py
+++ b/src/models/base_model.py
@@ -217,7 +217,7 @@ class BaseModel():
                         self.__patch_instance_norm_state_dict(state_dict, net, key.split('.'))
                     net.load_state_dict(state_dict)
                 else:
-                    print('falied loading the model from %s' % load_path)
+                    print('failed loading the model from %s' % load_path)
 
 
 


### PR DESCRIPTION
Fixes a typo in `src/models/base_model.py` where `print('falied loading the model...')` should be `print('failed loading the model...')`.

This is a user-visible error message shown when model loading fails.

**Before:** `print('falied loading the model from %s' % load_path)`
**After:** `print('failed loading the model from %s' % load_path)`

1 file, 1 line change.